### PR TITLE
skip chef-client run on chef 12+ systems

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -3,6 +3,8 @@ require 'fileutils'
 namespace :deploy do
   desc 'Run chef-client'
   task :chef_client do
+    # This is not needed with chef 12 systems
+    next unless File.exist?('/opt/chef/bin/shef')
     require 'open3'
 
     # -n for non-interactive


### PR DESCRIPTION
Chef-client should not be run on v12 systems; this should skip the task unless it finds the deprecated shell script 'shef'
